### PR TITLE
fix front-end typo from lenght to length

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 		</div></div>
 		<em style="position: relative; top: 2px;">left click on the left/right side of the bar to change its color; right click to copy hex</em>
 		<div class="topConfigs">
-			<div class="lenghtPicker"><h2>Gradient chain lenght:</h2>
+			<div class="lenghtPicker"><h2>Gradient chain length:</h2>
 				<input type="radio" name="cLenght" id="cLenght1" checked="checked"><label for="cLenght1" id="cLenghtBtn1">9 blocks
 				</label><input type="radio" name="cLenght" id="cLenght2"><label for="cLenght2" id="cLenghtBtn2">25 blocks
 				</label><input type="radio" name="cLenght" id="cLenght3"><label for="cLenght3" id="cLenghtBtn3">Custom...</label></div>


### PR DESCRIPTION
left backend classes the same even though some of them have the same typo