### PR TITLE
Fix block name position

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ $('#visUpscale').on('click', () => { if (visSize < 256) {
 /* update and show popup when block is hovered */
 function showPopup(block) {
 	$('#visPopup').html($(block).attr('blockname'));
-	$('#visPopup').css('left', block.x + 4).css('top', block.y + 4);
+	$('#visPopup').css('left', $(block).offset().left + 4).css('top', $(block).offset().top + 4);
 	$('#visPopup').show();
 }
 


### PR DESCRIPTION
Hi, great app! I noticed the block names were in a strange position/hidden when the blocks are upscaled.

https://user-images.githubusercontent.com/17814185/155282411-a9d2d97c-45bb-43f6-8ca6-85e741a5b280.mp4

